### PR TITLE
Enhancement to let callback know if the timer is currently running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage
 
     var timer = ProgressTimer({
         // Your callback for updating UI state, required.
-        callback: function(position, duration, is_running) {
+        callback: function(position, duration, isRunning) {
         },
         // Target milliseconds between callbacks, default: 100, min: 10.
         updateRate: 10,

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage
 
     var timer = ProgressTimer({
         // Your callback for updating UI state, required.
-        callback: function(position, duration) {
+        callback: function(position, duration, is_running) {
         },
         // Target milliseconds between callbacks, default: 100, min: 10.
         updateRate: 10,

--- a/demo.html
+++ b/demo.html
@@ -120,7 +120,7 @@
       document.getElementById('position').appendChild(positionNode);
       document.getElementById('duration').appendChild(durationNode);
 
-      function callback(position, duration) {
+      function callback(position, duration, is_running) {
         positionNode.nodeValue = format(position);
         durationNode.nodeValue = format(duration || 0);
 
@@ -161,7 +161,7 @@
               var updateRate = toInt(inputs['updateRate'].value);
               var disableRAF = inputs['disableRAF'].value === 'true';
               logger.log('var timer = new ProgressTimer({\n' +
-                         '  callback: function(position, duration) { /* UI code */ },\n' +
+                         '  callback: function(position, duration, is_running) { /* UI code */ },\n' +
                          '  disableRequestAnimationFrame: ' + disableRAF + ',\n' +
                          '  updateRate: ' + updateRate + '\n' +
                          '});');

--- a/demo.html
+++ b/demo.html
@@ -120,7 +120,7 @@
       document.getElementById('position').appendChild(positionNode);
       document.getElementById('duration').appendChild(durationNode);
 
-      function callback(position, duration, is_running) {
+      function callback(position, duration, isRunning) {
         positionNode.nodeValue = format(position);
         durationNode.nodeValue = format(duration || 0);
 
@@ -161,7 +161,7 @@
               var updateRate = toInt(inputs['updateRate'].value);
               var disableRAF = inputs['disableRAF'].value === 'true';
               logger.log('var timer = new ProgressTimer({\n' +
-                         '  callback: function(position, duration, is_running) { /* UI code */ },\n' +
+                         '  callback: function(position, duration, isRunning) { /* UI code */ },\n' +
                          '  disableRequestAnimationFrame: ' + disableRAF + ',\n' +
                          '  updateRate: ' + updateRate + '\n' +
                          '});');

--- a/timer.js
+++ b/timer.js
@@ -109,11 +109,14 @@ ProgressTimer.prototype._update = function(timestamp) {
             this._callback(Math.floor(position), duration, this._running);
             state.previousPosition = position;
         }
-        this._scheduleUpdate(timestamp);
     } else {
-        this._running = false;
+        // Workaround for https://github.com/adamcik/media-progress-timer/issues/3
+        // This causes the timer to die unexpectedly if the position goes
+        // over the duration slightly.
+        // this._running = false;
         this._callback(duration, duration, this._running);
     }
+    this._scheduleUpdate(timestamp);
 };
 
 if(typeof module !== 'undefined') {

--- a/timer.js
+++ b/timer.js
@@ -58,7 +58,7 @@ ProgressTimer.prototype.set = function(position, duration) {
         duration: duration
     };
 
-    this._callback(position, duration);
+    this._callback(position, duration, this._running);
     return this;
 };
 
@@ -106,13 +106,13 @@ ProgressTimer.prototype._update = function(timestamp) {
     if (position < duration || duration === null) {
         var delta = position - state.previousPosition;
         if (delta >= this._updateRate || this._fallback) {
-            this._callback(Math.floor(position), duration);
+            this._callback(Math.floor(position), duration, this._running);
             state.previousPosition = position;
         }
         this._scheduleUpdate(timestamp);
     } else {
         this._running = false;
-        this._callback(duration, duration);
+        this._callback(duration, duration, this._running);
     }
 };
 


### PR DESCRIPTION
This PR addresses a corner case that I came across while working on the Mopidy-Musicbox-Webclient.

Due to the way that slider events are handled in jQuery, it is necessary to stop the timer on `slidestart` so that it does not interfere with where the user wants to drag the slider to. The timer can then be started again on `slidestop`.

The problem is that `ProgressTimer.prototype.stop` does one more `set` operation to roll back to the state of the previous update, which in turn calls the `callback`. So even when the user stops the timer, the callback will still try to update the slider while the user is busy dragging it.

So the options are probably to:
1. either let the callback know that the timer is still running so that it can manage the slider updates manually (this PR); or
2. add an option to media-progress-timer to specify that all stops should be 'hard', with no roll-back to the previous state.
